### PR TITLE
fix: Disregard private messages

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,7 +10,9 @@ after_initialize do
 
     begin
       topic, opts, user = params
-
+      
+      next if topic.try(:private_message?)
+      
       topic_url = Topic.url(topic.id, topic.slug)
 
       uri = URI.parse(SiteSetting.slack_url)


### PR DESCRIPTION
Previously, any private messages would trigger Slack notifications, just skip over them now instead.
