### PR TITLE
feat: Category specific channels

### DIFF
--- a/assets/javascripts/discourse/connectors/category-custom-settings/slack-settings.hbs
+++ b/assets/javascripts/discourse/connectors/category-custom-settings/slack-settings.hbs
@@ -1,0 +1,10 @@
+{{#if siteSettings.allow_category_slack_channel}}
+<section class='field'>
+  <div class="slack-channel">
+    <label>
+      {{i18n 'slack.channel'}}
+      {{text-field value=category.slack_channel class="position-input"}}
+    </label>
+  </div>
+</section>
+{{/if}}

--- a/assets/javascripts/discourse/connectors/category-custom-settings/slack-settings.hbs
+++ b/assets/javascripts/discourse/connectors/category-custom-settings/slack-settings.hbs
@@ -3,7 +3,7 @@
   <div class="slack-channel">
     <label>
       {{i18n 'slack.channel'}}
-      {{text-field value=category.slack_channel class="position-input"}}
+      {{text-field value=category.slack_channel}}
     </label>
   </div>
 </section>

--- a/assets/javascripts/discourse/pre-initializers/extend-category-for-slack.js.es6
+++ b/assets/javascripts/discourse/pre-initializers/extend-category-for-slack.js.es6
@@ -1,0 +1,24 @@
+import property from 'ember-addons/ember-computed-decorators';
+import Category from 'discourse/models/category';
+
+export default {
+  name: 'extend-category-for-slack',
+  before: 'inject-discourse-objects',
+  initialize() {
+
+    Category.reopen({
+
+      @property('custom_fields.slack_channel')
+      slack_channel: {
+        get(channelField) {
+          return channelField;
+        },
+        set(value) {
+          this.set("custom_fields.slack_channel", value);
+          return value;
+        }
+      }
+
+    });
+  }
+};

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,3 +4,6 @@ en:
       site_settings:
         categories:
           slack: 'Slack'
+  js:
+    slack:
+      channel: "Slack channel"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,8 +2,9 @@ en:
   site_settings:
     slack_enabled: 'Check this to enable the Slack integration.'
     slack_url: 'Slack URL including access token.'
-    slack_channel: 'Slack channel to post this message to. (i.e. #general, @username)'
+    slack_channel: 'Slack channel to post this message to. (i.e. #general, @username). Leaving blank for no fallback is helpful if using "allow category slack channel" setting.'
     slack_emoji: 'Slack emoji to use.'
     slack_posts: 'Post all new posts to Slack (not just new topics).'
     slack_full_names: 'Shows user full names instead of usernames (shows username if user did not set one)'
     allow_category_slack_channel: 'Allows each category to specify a Slack channel to post to, falls back to parent categories or the global channel'
+    slack_category_name_in_title: 'Display the category name in the title of the post sent to Slack (e.g., "[category name] topic title")'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,3 +6,4 @@ en:
     slack_emoji: 'Slack emoji to use.'
     slack_posts: 'Post all new posts to Slack (not just new topics).'
     slack_full_names: 'Shows user full names instead of usernames (shows username if user did not set one)'
+    allow_category_slack_channel: 'Allows each category to specify a Slack channel to post to, falls back to parent categories or the global channel'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,3 +17,6 @@ slack:
   slack_full_names:
     client: true
     default: true
+  allow_category_slack_channel:
+    client: true
+    default: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,3 +20,6 @@ slack:
   allow_category_slack_channel:
     client: true
     default: false
+  slack_category_name_in_title:
+    client: true
+    default: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -25,19 +25,40 @@ after_initialize do
 
       display_name = (SiteSetting.slack_full_names && user.try(:name) && user.name.length > 0) ? user.name : user.username
 
+      # Default to the global site channel
+      channel = SiteSetting.slack_channel
+
+      # We might have a category specific channel to post to
+      if SiteSetting.allow_category_slack_channel
+        category = topic.category
+
+        # We walk up the categories to the root unless we find a
+        # channel setting on the category
+        while category != nil do
+          cat_channel = category.custom_fields["slack_channel"]
+
+          if cat_channel != nil
+            channel = cat_channel
+            break
+          end
+
+          category = category.parent_category
+        end
+      end
+
       request = Net::HTTP::Post.new(uri.path)
       request.add_field('Content-Type', 'application/json')
       request.body = {
         :username => SiteSetting.title,
         :icon_emoji => SiteSetting.slack_emoji,
-        :channel => SiteSetting.slack_channel,
+        :channel => channel,
         :attachments => [
           {
             :fallback => "New " + (post.try(:is_first_post?) ? "topic" : "post in #{topic.title}") + " by #{display_name} - #{post_url}",
             :pretext => "New " + (post.try(:is_first_post?) ? "topic" : "post") + " by #{display_name}:",
             :title => topic.title,
             :title_link => post_url,
-            :text => post.excerpt(200, text_entities: true, strip_links: true)
+            :text => post.excerpt(200, text_entities: false, strip_links: true)
           }
         ]
       }.to_json

--- a/plugin.rb
+++ b/plugin.rb
@@ -46,6 +46,8 @@ after_initialize do
         end
       end
 
+      next if channel.blank?
+
       request = Net::HTTP::Post.new(uri.path)
       request.add_field('Content-Type', 'application/json')
       request.body = {

--- a/plugin.rb
+++ b/plugin.rb
@@ -62,7 +62,7 @@ after_initialize do
             :pretext => "New " + (post.try(:is_first_post?) ? "topic" : "post") + " by #{display_name}:",
             :title => (show_category_name ? "[" + category.name + "] " : "") + topic.title,
             :title_link => post_url,
-            :text => post.excerpt(200, text_entities: false, strip_links: true)
+            :text => post.excerpt(200, text_entities: true, strip_links: true)
           }
         ]
       }.to_json

--- a/plugin.rb
+++ b/plugin.rb
@@ -28,9 +28,9 @@ after_initialize do
       # Default to the global site channel
       channel = SiteSetting.slack_channel
 
+      category = topic.category
       # We might have a category specific channel to post to
       if SiteSetting.allow_category_slack_channel
-        category = topic.category
 
         # We walk up the categories to the root unless we find a
         # channel setting on the category
@@ -48,6 +48,8 @@ after_initialize do
 
       next if channel.blank?
 
+      show_category_name = SiteSetting.slack_category_name_in_title
+
       request = Net::HTTP::Post.new(uri.path)
       request.add_field('Content-Type', 'application/json')
       request.body = {
@@ -58,7 +60,7 @@ after_initialize do
           {
             :fallback => "New " + (post.try(:is_first_post?) ? "topic" : "post in #{topic.title}") + " by #{display_name} - #{post_url}",
             :pretext => "New " + (post.try(:is_first_post?) ? "topic" : "post") + " by #{display_name}:",
-            :title => topic.title,
+            :title => (show_category_name ? "[" + category.name + "] " : "") + topic.title,
             :title_link => post_url,
             :text => post.excerpt(200, text_entities: false, strip_links: true)
           }


### PR DESCRIPTION
This adds the ability to turn on category specific channels, which
can be specified in the category settings when the setting is enabled.

If the category does not have a specific channel set, it falls back to
the parent category if there is one, otherwise it just uses the global
channel specified in the settings.
